### PR TITLE
Give menu icon and theme toggle an accessible name

### DIFF
--- a/src/lutra/assets/styles/scaffold/index.css
+++ b/src/lutra/assets/styles/scaffold/index.css
@@ -4,3 +4,4 @@
 @import "./icons.css";
 @import "./variables.css";
 @import "./theme.css";
+@import "./screen-readers.css";

--- a/src/lutra/assets/styles/scaffold/screen-readers.css
+++ b/src/lutra/assets/styles/scaffold/screen-readers.css
@@ -1,0 +1,11 @@
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}

--- a/src/lutra/theme/lutra/components/toggle-sidebar-primary.html
+++ b/src/lutra/theme/lutra/components/toggle-sidebar-primary.html
@@ -1,5 +1,6 @@
 {% extends "basic-ng/components/toggle-sidebar-primary.html" %}
 
 {% block content %}
+<div class="visually-hidden">Toggle site navigation sidebar</div>
 <svg class="h-6 w-6"><use href="#icon-collapse"></use></svg>
 {% endblock content %}

--- a/src/lutra/theme/lutra/partials/header/theme-toggle.html
+++ b/src/lutra/theme/lutra/partials/header/theme-toggle.html
@@ -1,4 +1,5 @@
 <button class="theme-toggle">
+  <div class="visually-hidden">Toggle Light / Dark / Auto color theme</div>
   <div class="theme-icon-when-auto">
     <svg><use href="#icon-theme-auto"></use></svg>
   </div>


### PR DESCRIPTION
Running Lighthouse in Chrome suggests a number of accessibility improvements, including:

> Buttons do not have an accessible name

<img width="715" alt="image" src="https://user-images.githubusercontent.com/1324225/224074891-879bb051-caaa-4a1b-9907-9257b6472cc7.png">

This is about the theme toggle. We can fix this in a similar way to [Furo](https://github.com/search?q=repo%3Apradyunsg%2Ffuro%20visually-hidden&type=code) by adding `<div class="visually-hidden">Toggle Light / Dark / Auto color theme</div>` to the button and using CSS to visually hide it.

This improves the Lighthouse accessibility score from 75 to 87.

# Before

<img width="407" alt="image" src="https://user-images.githubusercontent.com/1324225/224074515-3d876aac-7d2c-4cce-a6d2-ed4e36218771.png">

<img width="740" alt="image" src="https://user-images.githubusercontent.com/1324225/224074595-371c3752-1eea-4e83-8e66-d9c2dc44ed39.png">

# After

<img width="401" alt="image" src="https://user-images.githubusercontent.com/1324225/224074175-545251b7-7293-4c42-99f8-f0a5cf69f1c2.png">

<img width="731" alt="image" src="https://user-images.githubusercontent.com/1324225/224074330-49037165-d2b6-4052-a366-fac0f84feb1c.png">
