### PR TITLE
Fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,23 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
+    rev: v3.0.0-alpha.6
     hooks:
       - id: prettier
         exclude: src/.*\.html
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
-        language_version: python3.8
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: 1.13.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==21.8b0]
+        additional_dependencies: [black==23.1.0]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         files: \.py$
@@ -38,14 +37,12 @@ repos:
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.0.203"
+    rev: "v0.0.254"
     hooks:
       - id: ruff
-        # Respect `exclude` and `extend-exclude` settings.
-        args: ["--force-exclude"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.1.1
     hooks:
       - id: mypy
         args: [--disallow-untyped-defs, --ignore-missing-imports]
@@ -53,7 +50,7 @@ repos:
         additional_dependencies: [types-docutils]
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         files: src/.*\.py$

--- a/docs/project/kitchen-sink/blocks.rst
+++ b/docs/project/kitchen-sink/blocks.rst
@@ -187,6 +187,7 @@ This has an alias of ``code-block``.
 
     from typing import Iterator
 
+
     # This is an example
     class Math:
         @staticmethod


### PR DESCRIPTION
Replaces and closes https://github.com/pradyunsg/lutra/pull/39.

* `pre-commit autoupdate`
* Remove `language_version: python3.8` from Black to run on newer Python versions
* Remove `args: ["--force-exclude"]` from Ruff because it's now part of the action: https://github.com/charliermarsh/ruff-pre-commit/blob/9db230353b823e61e76b88bf2272329e3ad32c3a/.pre-commit-hooks.yaml
* Update Black in `blacken-docs` to `black==23.1.0` to match the main Black hook
* `pre-commit run --all-files` had a blacken-docs change