### PR TITLE
Adjust button contrast to meet WCAG AA guidelines

### DIFF
--- a/src/lutra/assets/styles/scaffold/variables.css
+++ b/src/lutra/assets/styles/scaffold/variables.css
@@ -163,7 +163,7 @@ html.dark {
 
   --border-hero_button--brand: transparent;
   --color_bg-hero_button--brand: var(--theme-brand);
-  --color_text-hero_button--brand: theme("colors.gray.100");
+  --color_text-hero_button--brand: theme("colors.gray.900");
 
   --color_bg-hero_feature: var(--color_bg-header);
   --color_text-hero-brand: var(--theme-brand);


### PR DESCRIPTION
Lighthouse 86% -> 91% by adjusting the foreground colour from light to dark grey. I used Chrome devtools suggestion.

Another option is to reduce the lightness of the background colour (for example using a tool like https://dequeuniversity.com/rules/axe/4.4/color-contrast) but that's the site brand colour (for things like the "Lutra" header) so I didn't touch that.

# Before

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/225324280-eee06d18-8a22-4f96-9139-f196fa0d6765.png">

# After

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/1324225/225324551-0a3eeab2-9b46-4c26-b5d6-2a973f0728da.png">