### PR TITLE
Autoupdate pre-commit quarterly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,6 @@ repos:
         entry: scripts/lint-css-variables.py
         language: script
         files: src/.*/variables\.css
+
+ci:
+  autoupdate_schedule: quarterly


### PR DESCRIPTION
I don't think we need weekly bumps of all the linters, quarterly or monthly should be enough.