### PR TITLE
Remove an auto-generated license file

### DIFF
--- a/src/lutra/theme/lutra/static/scripts/.gitignore
+++ b/src/lutra/theme/lutra/static/scripts/.gitignore
@@ -1,3 +1,4 @@
 # Don't include generated files under version control
 *.js
 *.js.map
+*.LICENSE.txt

--- a/src/lutra/theme/lutra/static/scripts/lutra.js.LICENSE.txt
+++ b/src/lutra/theme/lutra/static/scripts/lutra.js.LICENSE.txt
@@ -1,1 +1,0 @@
-/*! instant.page v5.1.0 - (C) 2019-2020 Alexandre Dieulot - https://instant.page/license */


### PR DESCRIPTION
This file should not be included in the source tree, since it's auto-generated.