### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To use the theme in your existing Sphinx documentation:
 
 For more information, visit [Lutra's documentation][quickstart-docs].
 
-[quickstart-docs]: https://pradyunsg.me/lutra/quickstart
+[quickstart-docs]: https://pradyunsg.me/lutra/quick-start/
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For more information, visit [Lutra's documentation][quickstart-docs].
 
 ## Contributing
 
-Lutra is a volunteer maintained open source project, and we welcome contributions of all forms. Please take a look at our [Contributing Guide](https://pradyunsg.me/lutra/contributing/) for more information.
+Lutra is a volunteer maintained open source project, and we welcome contributions of all forms. Please take a look at our [Contributing Guide](https://pradyunsg.me/lutra/project/) for more information.
 
 ## Acknowledgements
 


### PR DESCRIPTION
Hey there 👋,

I was looking through the project and noticed a couple links were broken in the README. This PR has two quick fixes for those. The first is hyphenating the link for quick-start which currently 404s.

The second change attempts to fix the contributing link, but I wasn't able to find an exact match. The project page appears to be the closest thing to a contributing landing page. Let me know if there's somewhere better.