### PR TITLE
Move all custom logic for pygments into a dedicated module

### DIFF
--- a/src/lutra/__init__.py
+++ b/src/lutra/__init__.py
@@ -12,9 +12,7 @@ from typing import Any, Dict, List, Optional
 import sphinx.application
 import sphinx.config
 from docutils import nodes
-from pygments.formatters import HtmlFormatter
 from pygments.style import Style
-from pygments.token import Text
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.highlighting import PygmentsBridge
 from sphinx.locale import get_translation
@@ -27,6 +25,7 @@ from ._directives import (
 )
 from ._errors import LutraError
 from ._navigation import determine_navigation_information, should_hide_toc
+from ._pygments import get_pygments_style_colors, get_pygments_stylesheet
 
 THEME_PATH = (Path(__file__).parent / "theme" / "lutra").resolve()
 
@@ -68,39 +67,6 @@ class WrapTableAndMathInAContainerTransform(SphinxPostTransform):
             new_node.update_all_atts(node)
             node.parent.replace(node, new_node)
             new_node.append(node)
-
-
-def get_pygments_style_colors(
-    style: Style, *, fallbacks: Dict[str, str]
-) -> Dict[str, str]:
-    """Get background/foreground colors for given pygments style."""
-    background = style.background_color
-    text_colors = style.style_for_token(Text)
-    foreground = text_colors["color"]
-
-    if not background:
-        background = fallbacks["background"]
-
-    if not foreground:
-        foreground = fallbacks["foreground"]
-    else:
-        foreground = f"#{foreground}"
-
-    return {"background": background, "foreground": foreground}
-
-
-@lru_cache(maxsize=2)
-def get_colors_for_codeblocks(
-    highlighter: PygmentsBridge, *, fg: str, bg: str
-) -> Dict[str, str]:
-    """Get background/foreground colors for given pygments style."""
-    return get_pygments_style_colors(
-        highlighter.formatter_args["style"],
-        fallbacks={
-            "foreground": fg,
-            "background": bg,
-        },
-    )
 
 
 @lru_cache
@@ -243,43 +209,6 @@ def _get_dark_style(app: sphinx.application.Sphinx) -> Style:
     return PygmentsBridge("html", dark_style).formatter_args["style"]
 
 
-def get_pygments_stylesheet() -> str:
-    """Generate the theme-specific pygments.css.
-
-    There is no way to tell Sphinx how the theme handles dark mode; at this time.
-    """
-    light_formatter = HtmlFormatter(style=_KNOWN_STYLES_IN_USE["light"])
-    dark_formatter = HtmlFormatter(style=_KNOWN_STYLES_IN_USE["dark"])
-
-    light_prefix = "html:not(.dark) .highlight"
-    dark_prefix = "html.dark .highlight"
-
-    # This section uses the "internal" methods of HtmlFormatter, to get the styles
-    # such that they're namespaced. This helps ensure that they only apply on the
-    # relevant styles.
-    lines = []
-    lines.extend(
-        [
-            f"{light_prefix} {line}"
-            for line in light_formatter.get_linenos_style_defs()
-            if not line.startswith("pre {")
-        ]
-    )
-    lines.extend(light_formatter.get_background_style_defs(light_prefix))
-    lines.extend(light_formatter.get_token_style_defs(light_prefix))
-    lines.extend(
-        [
-            f"{dark_prefix} {line}"
-            for line in dark_formatter.get_linenos_style_defs()
-            if not line.startswith("pre {")
-        ]
-    )
-    lines.extend(dark_formatter.get_background_style_defs(dark_prefix))
-    lines.extend(dark_formatter.get_token_style_defs(dark_prefix))
-
-    return "\n".join(lines)
-
-
 def _build_finished(
     app: sphinx.application.Sphinx,
     exception: Optional[Exception],
@@ -291,7 +220,12 @@ def _build_finished(
     # needs from it, compared to what Sphinx generates.
     assert app.builder
     with open(os.path.join(app.builder.outdir, "_static", "pygments.css"), "w") as f:
-        f.write(get_pygments_stylesheet())
+        f.write(
+            get_pygments_stylesheet(
+                light_style=_KNOWN_STYLES_IN_USE["light"],
+                dark_style=_KNOWN_STYLES_IN_USE["dark"],
+            )
+        )
 
 
 def setup(app: sphinx.application.Sphinx) -> Dict[str, Any]:

--- a/src/lutra/_pygments.py
+++ b/src/lutra/_pygments.py
@@ -1,0 +1,77 @@
+from functools import lru_cache
+from typing import Dict
+
+from pygments.formatters import HtmlFormatter
+from pygments.style import Style
+from pygments.token import Text
+from sphinx.highlighting import PygmentsBridge
+
+
+def get_pygments_style_colors(
+    style: Style, *, fallbacks: Dict[str, str]
+) -> Dict[str, str]:
+    """Get background/foreground colors for given pygments style."""
+    background = style.background_color
+    text_colors = style.style_for_token(Text)
+    foreground = text_colors["color"]
+
+    if not background:
+        background = fallbacks["background"]
+
+    if not foreground:
+        foreground = fallbacks["foreground"]
+    else:
+        foreground = f"#{foreground}"
+
+    return {"background": background, "foreground": foreground}
+
+
+@lru_cache(maxsize=2)
+def get_colors_for_codeblocks(
+    highlighter: PygmentsBridge, *, fg: str, bg: str
+) -> Dict[str, str]:
+    """Get background/foreground colors for given pygments style."""
+    return get_pygments_style_colors(
+        highlighter.formatter_args["style"],
+        fallbacks={
+            "foreground": fg,
+            "background": bg,
+        },
+    )
+
+
+def get_pygments_stylesheet(light_style: Style, dark_style: Style) -> str:
+    """Generate the theme-specific pygments.css.
+
+    There is no way to tell Sphinx how the theme handles dark mode; at this time.
+    """
+    light_formatter = HtmlFormatter(style=light_style)
+    dark_formatter = HtmlFormatter(style=dark_style)
+
+    light_prefix = "html:not(.dark) .highlight"
+    dark_prefix = "html.dark .highlight"
+
+    # This section uses the "internal" methods of HtmlFormatter, to get the styles
+    # such that they're namespaced. This helps ensure that they only apply on the
+    # relevant styles.
+    lines = []
+    lines.extend(
+        [
+            f"{light_prefix} {line}"
+            for line in light_formatter.get_linenos_style_defs()
+            if not line.startswith("pre {")
+        ]
+    )
+    lines.extend(light_formatter.get_background_style_defs(light_prefix))
+    lines.extend(light_formatter.get_token_style_defs(light_prefix))
+    lines.extend(
+        [
+            f"{dark_prefix} {line}"
+            for line in dark_formatter.get_linenos_style_defs()
+            if not line.startswith("pre {")
+        ]
+    )
+    lines.extend(dark_formatter.get_background_style_defs(dark_prefix))
+    lines.extend(dark_formatter.get_token_style_defs(dark_prefix))
+
+    return "\n".join(lines)


### PR DESCRIPTION
This makes it easier to confirm that this is logically separated from any Sphinx-specific logic, and also makes it easier to test.